### PR TITLE
Ready for new version release

### DIFF
--- a/.changeset/long-tigers-wave.md
+++ b/.changeset/long-tigers-wave.md
@@ -1,0 +1,9 @@
+---
+"@ayu-sh-kr/dota-core": patch
+---
+
+Bug fix for the PropertyType Function
+
+Exported HostListener from the module
+
+Added test to the code base

--- a/src/core/decorators/index.ts
+++ b/src/core/decorators/index.ts
@@ -6,6 +6,7 @@ import { Property } from '@dota/core/decorators/property.decorator.ts';
 import { EventListener } from '@dota/core/decorators/event-listener.decorator.ts';
 import { Expose } from '@dota/core/decorators/expose.decorator.ts';
 import { Emitter } from '@dota/core/decorators/event.decorator.ts';
+import {HostListener} from "@src/core/decorators/host-listener.decorator.ts";
 
 export {
     AfterInit,
@@ -15,5 +16,6 @@ export {
     Property,
     EventListener,
     Expose,
-    Emitter
+    Emitter,
+    HostListener
 };

--- a/src/core/helper/bootstrap.utils.ts
+++ b/src/core/helper/bootstrap.utils.ts
@@ -3,10 +3,10 @@ import {HelperUtils} from "@dota/core/helper";
 
 
 /**
- * Bootstraps custom elements by defining them with the custom elements registry.
+ * Bootstraps custom elements by defining them with the custom elements' registry.
  *
  * The `bootstrap` function takes an array of custom element constructors and registers them
- * with the custom elements registry. It retrieves the component metadata using `HelperUtils.getComponentMetadata`
+ * with the custom elements' registry. It retrieves the component metadata using `HelperUtils.getComponentMetadata`
  * and defines the custom element if it is not already defined.
  *
  * @param {CustomElementConstructor[]} elements - An array of custom element constructors to be registered.


### PR DESCRIPTION
This pull request includes several changes to the `@dota/core` module, focusing on bug fixes, exporting new decorators, and improving documentation. The most important changes include a bug fix for the `PropertyType` function, exporting the `HostListener` decorator, and updating the documentation for the `bootstrap` function.

### Bug Fixes and Features:

* [`.changeset/long-tigers-wave.md`](diffhunk://#diff-719687cfca9558b9c172af0f81e1a8cf329ed3479d42853f9d13b1317001f1cbR1-R9): Added a patch for the `PropertyType` function and exported the `HostListener` from the module. Also included a new test to the codebase.

* [`src/core/decorators/index.ts`](diffhunk://#diff-d4285e3ac0a54a60b6e8fea1c97184f33e21a96ed9fc0aaf37e3b5108b3843e2R9): Imported and exported the `HostListener` decorator. [[1]](diffhunk://#diff-d4285e3ac0a54a60b6e8fea1c97184f33e21a96ed9fc0aaf37e3b5108b3843e2R9) [[2]](diffhunk://#diff-d4285e3ac0a54a60b6e8fea1c97184f33e21a96ed9fc0aaf37e3b5108b3843e2L18-R20)

### Documentation Improvements:

* [`src/core/helper/bootstrap.utils.ts`](diffhunk://#diff-8159e4bdc24d2e69a3d6808fcfd12e009b4454ebdabbd11e4df94f9288b99d8dL6-R9): Updated the documentation for the `bootstrap` function to clarify the usage of the custom elements' registry.