### PR TITLE
New feature to add multiple events to config for HostListener and WindowListener

### DIFF
--- a/.changeset/sour-pans-scream.md
+++ b/.changeset/sour-pans-scream.md
@@ -1,0 +1,5 @@
+---
+"@ayu-sh-kr/dota-core": patch
+---
+
+Update event binding mechanism, enable to bind multiple event to same method using the single decorator

--- a/src/core/decorators/window-listener.decorator.ts
+++ b/src/core/decorators/window-listener.decorator.ts
@@ -9,7 +9,7 @@ import {EventOptions, HelperUtils, EventOptionMeta} from "@src/core";
  * execute the decorated method when the event is triggered.
  *
  * @param {EventOptions} config - Configuration options for the event listener.
- * @param {string} config.event - The type of the event to bind to the method (e.g., 'click', 'resize').
+ * @param {string | string[]} config.event - The type of the event to bind to the method (e.g., 'click', 'resize').
  *
  * @returns {MethodDecorator} - A method decorator that binds the specified event to the method.
  *

--- a/src/core/types/core.types.ts
+++ b/src/core/types/core.types.ts
@@ -245,7 +245,7 @@ interface EventDetails {
  * }
  */
 interface EventOptions {
-    event: string
+    event: string | string[]
 }
 
 
@@ -262,7 +262,7 @@ interface EventOptions {
  * @property {function} method - The method itself which is going to be bounded.
  */
 interface EventOptionMeta {
-    event: string,
+    event: string | string[],
     name: string
     method: Function
 }


### PR DESCRIPTION
This pull request updates the event binding mechanism to support binding multiple events to the same method using a single decorator. The changes span across several files, including updates to type definitions, method implementations, and documentation.

### Event Binding Enhancements:

* [`.changeset/sour-pans-scream.md`](diffhunk://#diff-8feb0e36c4c6dc5bd487677da5756a2c7b6f4229a4499aec5cc0dff4984e94a0R1-R5): Updated event binding mechanism to enable binding multiple events to the same method using a single decorator. (`[.changeset/sour-pans-scream.mdR1-R5](diffhunk://#diff-8feb0e36c4c6dc5bd487677da5756a2c7b6f4229a4499aec5cc0dff4984e94a0R1-R5)`)
* [`src/core/decorators/window-listener.decorator.ts`](diffhunk://#diff-536c952a2a51e39c2cde6d202990c48486e98cd7567adb906bef9560c2fea450L12-R12): Modified `EventOptions` to allow `string` or `string[]` types for event binding. (`[src/core/decorators/window-listener.decorator.tsL12-R12](diffhunk://#diff-536c952a2a51e39c2cde6d202990c48486e98cd7567adb906bef9560c2fea450L12-R12)`)
* [`src/core/elements/base-elements.ts`](diffhunk://#diff-cb80eb1a739e3a47919a5cddf80c6be4f2834a03acf621490b9e011e6ffcee0eL365-R368): Updated `bindHostEvents` and `bindWindowEvents` methods to handle both single and multiple event bindings. (`[[1]](diffhunk://#diff-cb80eb1a739e3a47919a5cddf80c6be4f2834a03acf621490b9e011e6ffcee0eL365-R368)`, `[[2]](diffhunk://#diff-cb80eb1a739e3a47919a5cddf80c6be4f2834a03acf621490b9e011e6ffcee0eR394-R400)`, `[[3]](diffhunk://#diff-cb80eb1a739e3a47919a5cddf80c6be4f2834a03acf621490b9e011e6ffcee0eL403-R414)`, `[[4]](diffhunk://#diff-cb80eb1a739e3a47919a5cddf80c6be4f2834a03acf621490b9e011e6ffcee0eR437-R443)`)

### Type Definition Updates:

* [`src/core/types/core.types.ts`](diffhunk://#diff-d00cc5ddf82c3aac1d3d0767dfb93c3a94f722af7f0b42bc38bc84269437076cL248-R248): Updated `EventOptions` and `EventOptionMeta` interfaces to support `string | string[]` for event properties. (`[[1]](diffhunk://#diff-d00cc5ddf82c3aac1d3d0767dfb93c3a94f722af7f0b42bc38bc84269437076cL248-R248)`, `[[2]](diffhunk://#diff-d00cc5ddf82c3aac1d3d0767dfb93c3a94f722af7f0b42bc38bc84269437076cL265-R265)`)