### PR TITLE
Chores/fixes

### DIFF
--- a/.changeset/chilly-spies-draw.md
+++ b/.changeset/chilly-spies-draw.md
@@ -1,0 +1,5 @@
+---
+"@ayu-sh-kr/dota-core": patch
+---
+
+Removed unwanted logging throughout the library

--- a/src/core/helper/bootstrap.utils.ts
+++ b/src/core/helper/bootstrap.utils.ts
@@ -24,9 +24,14 @@ import {HelperUtils} from "@dota/core/helper";
  */
 export const bootstrap = (elements: CustomElementConstructor[]) => {
     elements.forEach(element => {
-        const meta:ComponentConfig = HelperUtils.getComponentMetadata(element, 'Component');
+        const meta: ComponentConfig = HelperUtils.getComponentMetadata(element, 'Component');
 
-        if(!customElements.get(meta.selector)) {
+        if (!meta) {
+            console.warn(`No metadata found for ${element.name}`);
+            return;
+        }
+
+        if (!customElements.get(meta.selector)) {
             customElements.define(meta.selector, element);
         }
 

--- a/src/core/helper/helper.utils.ts
+++ b/src/core/helper/helper.utils.ts
@@ -69,7 +69,6 @@ export class HelperUtils {
                         element.setAttribute(value.name, v);
 
                         const watchers = HelperUtils.fetchOrCreate<WatcherOptionMeta>(element, `Watcher:${value.prototype}`);
-                        console.info(`Watchers for ${propertyKey}:`, watchers);
                         if (watchers && watchers.size > 0) {
                             watchers.forEach((item: WatcherOptionMeta) => {
                                 if(element[item.name] && typeof element[item.name] === 'function') {
@@ -98,9 +97,8 @@ export class HelperUtils {
      */
     static getComponentMetadata(targetClass: Object, decoratorName: string): any {
         if(Reflect.hasOwnMetadata(decoratorName, targetClass)) {
-            console.log(true)
+            return Reflect.getOwnMetadata(decoratorName, targetClass);
         }
-        return Reflect.getOwnMetadata(decoratorName, targetClass);
     }
 
 }


### PR DESCRIPTION
This pull request includes changes to improve logging practices and enhance error handling in the `@ayu-sh-kr/dota-core` library. The most important changes involve removing unnecessary logging, adding a warning for missing metadata, and cleaning up redundant code.

### Logging improvements:

* [`.changeset/chilly-spies-draw.md`](diffhunk://#diff-0d804b0c63921b1ee86f24e82ce5ca763eef17e246b5da30ff4797fecf639b1bR1-R5): Removed unwanted logging throughout the library, as described in the changeset. This is categorized as a patch update for `@ayu-sh-kr/dota-core`.
* [`src/core/helper/helper.utils.ts`](diffhunk://#diff-b9deac85338b0b26d804565511d4c8076093945b2cf541e205caecd337760dc7L72): Removed a `console.info` statement that logged watcher details for properties, reducing unnecessary console output.
* [`src/core/helper/helper.utils.ts`](diffhunk://#diff-b9deac85338b0b26d804565511d4c8076093945b2cf541e205caecd337760dc7L101-R102): Removed a redundant `console.log` statement that was logging `true` without any context in the `getComponentMetadata` method.

### Error handling enhancement:

* [`src/core/helper/bootstrap.utils.ts`](diffhunk://#diff-8159e4bdc24d2e69a3d6808fcfd12e009b4454ebdabbd11e4df94f9288b99d8dR29-R33): Added a warning (`console.warn`) to notify when metadata is missing for a custom element, improving error visibility during the bootstrap process.