### PR TITLE
Feat/state decorator

### DIFF
--- a/src/core/decorators/index.ts
+++ b/src/core/decorators/index.ts
@@ -11,3 +11,4 @@ export {WindowListener} from "@dota/core/decorators/window-listener.decorator.ts
 export {Watcher} from "@dota/core/decorators/watcher.decorator.ts";
 export {DocumentListener} from "@dota/core/decorators/document-listener.decorator.ts";
 export {Param} from "@dota/core/decorators/param.decorator.ts";
+export {State} from "@dota/core/decorators/state.decorator.ts";

--- a/src/core/decorators/state.decorator.ts
+++ b/src/core/decorators/state.decorator.ts
@@ -1,0 +1,21 @@
+import {HelperUtils, StateConfig} from "@dota/core";
+
+/**
+ * Decorator to mark a property as a state property.
+ *
+ * This decorator is used to define a property as a state property in a component.
+ * It registers the property in the metadata for the component, allowing it to be
+ * tracked and updated accordingly.
+ *
+ * @returns {PropertyDecorator} - The property decorator function.
+ */
+function StateDecorator(): PropertyDecorator {
+  return function (target, propertyKey) {
+    const data = HelperUtils.fetchOrCreate<StateConfig>(target, 'State');
+    const key = propertyKey.toString();
+
+    data.set(key, {prototype: key})
+  }
+}
+
+export {StateDecorator as State}

--- a/src/core/elements/base-elements.ts
+++ b/src/core/elements/base-elements.ts
@@ -3,7 +3,7 @@ import {
   BindConfig, EventDetails,
   EventOptionMeta,
   MethodDetails, ParameterConfig,
-  PropertyDetails
+  PropertyDetails, StateConfig
 } from "@dota/core/types";
 import {EventEmitter, Sanitizer} from "@dota/core/utils";
 import {EventManagerService} from "@dota/core/services";
@@ -45,10 +45,11 @@ export abstract class BaseElement extends HTMLElement {
     const bindWindowEvents = this.bindWindowEvents();
     const bindDocumentEvents = this.bindDocumentEvents();
     const bindParameters = this.bindParameters();
+    const bindState = this.bindState(this);
 
     Promise.all([
       exposedMethods, bindMethods, bindEmitter, bindHostEvents,
-      bindWindowEvents, bindDocumentEvents, bindParameters
+      bindWindowEvents, bindDocumentEvents, bindParameters, bindState
     ])
       .catch((reason) => console.error(reason));
 
@@ -506,6 +507,42 @@ export abstract class BaseElement extends HTMLElement {
         this[key] = params.get(value.name)
       })
     }
+  }
+
+  /**
+   * Binds state properties to the component's properties based on metadata.
+   *
+   * This method retrieves metadata associated with the component's constructor
+   * to find state configurations. It then binds the specified state properties
+   * to the corresponding properties on the component, allowing for reactive updates
+   * and change detection.
+   *
+   * @method bindState
+   */
+  private async bindState(element: BaseElement) {
+    let data = HelperUtils.fetchOrCreate<StateConfig>(element, 'State');
+
+    data.forEach((value: StateConfig) => {
+      const propertyKey = `_${value.prototype}`
+
+      Object.defineProperty(element, value.prototype, {
+        get(): any {
+          return element[propertyKey]
+        },
+
+        set(v: any) {
+          if (element[propertyKey] !== v) {
+            element[propertyKey] = v;
+            element.updateHTML();
+
+            HelperUtils.bindWatchers(element, value.prototype);
+          }
+        },
+
+        enumerable: true,
+        configurable: true
+      });
+    });
   }
 
 

--- a/src/core/helper/helper.utils.ts
+++ b/src/core/helper/helper.utils.ts
@@ -1,5 +1,6 @@
 import "reflect-metadata";
 import {PropertyDetails, WatcherOptionMeta} from "@dota/core/types";
+import {BaseElement} from "@dota/core";
 
 export class HelperUtils {
 
@@ -68,14 +69,7 @@ export class HelperUtils {
             element[propertyKey] = v;
             element.setAttribute(value.name, v);
 
-            const watchers = HelperUtils.fetchOrCreate<WatcherOptionMeta>(element, `Watcher:${value.prototype}`);
-            if (watchers && watchers.size > 0) {
-              watchers.forEach((item: WatcherOptionMeta) => {
-                if (element[item.name] && typeof element[item.name] === 'function') {
-                  item.method.call(element);
-                }
-              });
-            }
+            HelperUtils.bindWatchers(element, value.prototype);
           }
         },
 
@@ -87,6 +81,17 @@ export class HelperUtils {
     element.reactive = true;
   }
 
+
+  static bindWatchers(element: BaseElement, prototype: string) {
+    const watchers = HelperUtils.fetchOrCreate<WatcherOptionMeta>(element, `Watcher:${prototype}`);
+    if (watchers && watchers.size > 0) {
+      watchers.forEach((item: WatcherOptionMeta) => {
+        if (element[item.name] && typeof element[item.name] === 'function') {
+          item.method.call(element);
+        }
+      });
+    }
+  }
 
   /**
    * Extracts metadata for a given decorator from a class.

--- a/src/core/types/core.types.ts
+++ b/src/core/types/core.types.ts
@@ -358,3 +358,8 @@ export type EventBindCollection = Map<EventBindType, Map<string, EventBindRecord
 export interface ParameterConfig {
   name: string
 }
+
+
+export interface StateConfig {
+  prototype: string
+}


### PR DESCRIPTION
This pull request introduces a new `State` decorator to manage state properties in components, along with supporting changes to integrate this functionality into the framework. The key changes include the creation of the `State` decorator, enhancements to the `BaseElement` class to bind state properties, and updates to utility functions for improved watcher handling.

### New Feature: State Decorator

* Added a `State` decorator in `src/core/decorators/state.decorator.ts` to mark properties as stateful, enabling metadata-based tracking and updates.
* Exported the `State` decorator in `src/core/decorators/index.ts` for external usage.

### Integration with BaseElement

* Updated `BaseElement` in `src/core/elements/base-elements.ts` to include a new `bindState` method, which binds state properties to component properties using metadata for reactive updates and change detection.
* Modified the initialization process in `BaseElement` to include the `bindState` method in the list of asynchronous bindings.

### Utility Enhancements

* Added a `bindWatchers` utility method in `HelperUtils` to centralize and simplify watcher binding logic.
* Replaced inline watcher binding logic in `HelperUtils` with calls to the new `bindWatchers` method for consistency and reusability.

### Type Definitions

* Introduced a new `StateConfig` interface in `src/core/types/core.types.ts` to define the structure of state metadata.
* Imported `StateConfig` into `BaseElement` to support state binding logic.