### PR TITLE
Feat/element decorator

### DIFF
--- a/.changeset/spotty-tables-grow.md
+++ b/.changeset/spotty-tables-grow.md
@@ -1,0 +1,5 @@
+---
+"@ayu-sh-kr/dota-core": patch
+---
+
+Add new decorator @Element to bind components Element to its property

--- a/package.json
+++ b/package.json
@@ -7,6 +7,16 @@
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "typings": "dist/index.d.ts",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
+
   "files": [
     "dist"
   ],

--- a/src/core/decorators/element.decorator.ts
+++ b/src/core/decorators/element.decorator.ts
@@ -1,0 +1,34 @@
+import {ElementConfig, ElementConfigInternal, HelperUtils} from "@dota/core";
+
+/**
+ * A decorator that binds a property to a specified element configuration.
+ *
+ * This decorator allows you to specify an element configuration that will be used
+ * to bind the decorated property to the element. The configuration includes the
+ * selector name and type.
+ *
+ * @param {ElementConfig} config - The configuration for the element binding.
+ * @returns {PropertyDecorator} - A property decorator function.
+ *
+ * @example
+ * // Example of using ElementDecorator to bind a property to an element
+ * class MyComponent {
+ *   \@Element({ selector: 'div', type: 'tag' })
+ *   public myProperty: string;
+ * }
+ *
+ * // The myProperty will now be bound to the element with the specified configuration
+ * // and can be used in the component's logic.
+ *
+ */
+function ElementDecorator(config: ElementConfig): PropertyDecorator {
+  return function (target, propertyKey) {
+    const data = HelperUtils.fetchOrCreate<ElementConfigInternal>(target, 'Element');
+    data.set(propertyKey.toString(), {
+      ...config,
+      property: propertyKey.toString(),
+    })
+  }
+}
+
+export {ElementDecorator as Element}

--- a/src/core/decorators/index.ts
+++ b/src/core/decorators/index.ts
@@ -12,3 +12,4 @@ export {Watcher} from "@dota/core/decorators/watcher.decorator.ts";
 export {DocumentListener} from "@dota/core/decorators/document-listener.decorator.ts";
 export {Param} from "@dota/core/decorators/param.decorator.ts";
 export {State} from "@dota/core/decorators/state.decorator.ts";
+export {Element} from "@dota/core/decorators/element.decorator.ts";

--- a/src/core/elements/base-elements.ts
+++ b/src/core/elements/base-elements.ts
@@ -1,6 +1,6 @@
 import {HelperUtils} from "@dota/core/helper";
 import {
-  BindConfig, EventDetails,
+  BindConfig, ElementConfigInternal, EventDetails,
   EventOptionMeta,
   MethodDetails, ParameterConfig,
   PropertyDetails, StateConfig
@@ -46,10 +46,12 @@ export abstract class BaseElement extends HTMLElement {
     const bindDocumentEvents = this.bindDocumentEvents();
     const bindParameters = this.bindParameters();
     const bindState = this.bindState(this);
+    const bindElements = this.bindElements();
 
     Promise.all([
       exposedMethods, bindMethods, bindEmitter, bindHostEvents,
-      bindWindowEvents, bindDocumentEvents, bindParameters, bindState
+      bindWindowEvents, bindDocumentEvents, bindParameters, bindState,
+      bindElements
     ])
       .catch((reason) => console.error(reason));
 
@@ -84,7 +86,10 @@ export abstract class BaseElement extends HTMLElement {
     } else {
       this.innerHTML = this.render();
     }
-    this.bindMethods()
+    const bindMethods = this.bindMethods();
+    const bindElements = this.bindElements();
+
+    Promise.all([bindMethods, bindElements])
       .catch((reason) => console.error(reason));
   }
 
@@ -171,6 +176,7 @@ export abstract class BaseElement extends HTMLElement {
 
     if (fun) {
       fun.apply(this);
+      this.updateHTML();
     }
 
   }
@@ -543,6 +549,33 @@ export abstract class BaseElement extends HTMLElement {
         configurable: true
       });
     });
+  }
+
+  /**
+   * Binds elements to the component's properties based on metadata.
+   *
+   * This method retrieves metadata associated with the component's constructor
+   * to find element configurations. It then binds the specified elements to
+   * the corresponding properties on the component, allowing for easy access
+   * to DOM elements within the component.
+   *
+   * @method bindElements
+   */
+  private async bindElements() {
+    const data = HelperUtils.fetchOrCreate<ElementConfigInternal>(this, 'Element');
+    if (!data) return;
+
+    data.forEach((value) => {
+      let selector = '';
+      if (value.by === 'id') selector = `#${value.selector}`;
+      if (value.by === 'class') selector = `.${value.selector}`;
+      if (value.by === 'tag') selector = value.selector;
+      if (this.isShadow) {
+        this[value.property] = this.shadowRoot.querySelector(selector)
+        return;
+      }
+      this[value.property] = this.querySelector(selector)
+    })
   }
 
 

--- a/src/core/types/core.types.ts
+++ b/src/core/types/core.types.ts
@@ -360,6 +360,83 @@ export interface ParameterConfig {
 }
 
 
+/**
+ * Configuration object for defining a state in a custom element.
+ *
+ * This interface defines the structure for storing state details that are used
+ * by the `@State` decorator to define states in custom elements. It includes
+ * the prototype of the state.
+ *
+ * @interface StateConfig
+ *
+ * @property {string} prototype - The prototype of the state.
+ * This property specifies the prototype of the state that is being defined.
+ *
+ * @example
+ * // Example of using StateConfig to store state information
+ * const stateConfig: StateConfig = {
+ *     prototype: 'myState'
+ * };
+ */
 export interface StateConfig {
   prototype: string
+}
+
+/**
+ * Configuration object for defining an element in a custom element.
+ *
+ * This interface defines the structure for storing element details that are used
+ * by the `@Element` decorator to define elements in custom elements. It includes
+ * the selector and the method of selecting the element (e.g., 'id', 'tag', 'class').
+ *
+ * @interface ElementConfig
+ *
+ * @property {string} selector - The selector for the element.
+ * This property specifies the selector used to identify the element.
+ *
+ * @property {'id' | 'tag' | 'class'} by - The method of selecting the element.
+ * This property specifies the method used to select the element (e.g., 'id', 'tag', 'class').
+ *
+ * @example
+ * // Example of using ElementConfig to store element information
+ * const elementConfig: ElementConfig = {
+ *     selector: '#myElement',
+ *     by: 'id'
+ * };
+ */
+export interface ElementConfig {
+  selector: string;
+  by: 'id' | 'tag' | 'class'
+}
+
+/**
+ * Configuration object for defining an element in a custom element.
+ *
+ * This interface defines the structure for storing element details that are used
+ * by the `@Element` decorator to define elements in custom elements. It includes
+ * the selector and the method of selecting the element (e.g., 'id', 'tag', 'class').
+ *
+ * @interface ElementConfigInternal
+ *
+ * @property {string} selector - The selector for the element.
+ * This property specifies the selector used to identify the element.
+ *
+ * @property {'id' | 'tag' | 'class'} by - The method of selecting the element.
+ * This property specifies the method used to select the element (e.g., 'id', 'tag', 'class').
+ *
+ * @property {string} property - The name of the property in the class.
+ * This property specifies the name of the property in the class that corresponds to the element.
+ *
+ * @example
+ * // Example of using ElementConfigInternal to store element information
+ * const elementConfigInternal: ElementConfigInternal = {
+ *     selector: '#myElement',
+ *     by: 'id',
+ *     property: 'myElementProperty'
+ * };
+ */
+export interface ElementConfigInternal {
+  selector: string;
+  by: 'id' | 'tag' | 'class';
+  property: string;
 }


### PR DESCRIPTION
This pull request introduces a new `@Element` decorator to bind DOM elements to class properties, along with the necessary infrastructure to support this feature. The changes include the addition of the decorator, updates to the base element class to handle element bindings, and the introduction of new types for element configuration.

### New Feature: `@Element` Decorator

* **Decorator Implementation**: Added the `@Element` decorator in `src/core/decorators/element.decorator.ts`. This decorator allows binding a DOM element to a class property using a configuration object (`ElementConfig`).
* **Export in Index**: Exported the `@Element` decorator in `src/core/decorators/index.ts` to make it available for use across the codebase.

### Enhancements to `BaseElement`

* **Element Binding Logic**: Added the `bindElements` method to the `BaseElement` class in `src/core/elements/base-elements.ts`. This method uses metadata from the `@Element` decorator to bind DOM elements to properties.
* **Integration with Lifecycle**: Updated the `BaseElement` lifecycle methods to include calls to `bindElements`, ensuring elements are bound during initialization and updates. [[1]](diffhunk://#diff-cb80eb1a739e3a47919a5cddf80c6be4f2834a03acf621490b9e011e6ffcee0eR49-R54) [[2]](diffhunk://#diff-cb80eb1a739e3a47919a5cddf80c6be4f2834a03acf621490b9e011e6ffcee0eL87-R92) [[3]](diffhunk://#diff-cb80eb1a739e3a47919a5cddf80c6be4f2834a03acf621490b9e011e6ffcee0eR179)

### Type Definitions

* **New Types**: Introduced `ElementConfig` and `ElementConfigInternal` interfaces in `src/core/types/core.types.ts` to define the structure for element binding configurations. These types specify the selector, selection method (e.g., `id`, `class`, `tag`), and the corresponding property name.

### Documentation

* **Changeset**: Documented the addition of the `@Element` decorator in `.changeset/spotty-tables-grow.md`, marking it as a patch update for the `@ayu-sh-kr/dota-core` package.