### PR TITLE
Fix/event emitter

### DIFF
--- a/.changeset/two-snakes-explode.md
+++ b/.changeset/two-snakes-explode.md
@@ -1,0 +1,5 @@
+---
+"@ayu-sh-kr/dota-core": patch
+---
+
+Fix the EventEmitter class where custom event was bubbling by default

--- a/src/core/utils/EventEmitter.ts
+++ b/src/core/utils/EventEmitter.ts
@@ -27,10 +27,11 @@ export class EventEmitter<T> {
    *
    * @param {T} data - The data to be included in the event's detail.
    * @param {HTMLElement} [root] - The root element from which to dispatch the event. If not provided, the event is dispatched from the window.
+   * @param {boolean} [bubbles=false] - Indicates whether the event should bubble up through the DOM. Defaults to `false`.
    */
-  emit(data: T, root?: HTMLElement) {
+  emit(data: T, root?: HTMLElement, bubbles: boolean = false): void {
     const event = new CustomEvent<T>(this.name, {
-      bubbles: true,
+      bubbles: bubbles,
       detail: data
     })
 

--- a/test/core/utils/event-emitter.test.ts
+++ b/test/core/utils/event-emitter.test.ts
@@ -46,7 +46,7 @@ describe('EventEmitter', () => {
         const rootElement = document.createElement('div');
         document.body.appendChild(rootElement);
 
-        eventEmitter.emit(eventData, rootElement);
+        eventEmitter.emit(eventData, rootElement, true);
 
         expect(mockCallback).toHaveBeenCalledTimes(1);
         expect(mockCallback.mock.calls[0][0].detail).toEqual(eventData);
@@ -54,4 +54,24 @@ describe('EventEmitter', () => {
         window.removeEventListener(eventName, mockCallback);
         document.body.removeChild(rootElement);
     });
+
+  it('should not bubble the event up to the window object when bubbling is disabled', () => {
+    const eventName = 'testEvent';
+    const eventData = { key: 'value' };
+    const eventEmitter = new EventEmitter<typeof eventData>(eventName);
+
+    const mockCallback = jest.fn();
+    window.addEventListener(eventName, mockCallback);
+
+    const rootElement = document.createElement('div');
+    document.body.appendChild(rootElement);
+
+    // Emit without bubbling (default)
+    eventEmitter.emit(eventData, rootElement);
+
+    expect(mockCallback).not.toHaveBeenCalled();
+
+    window.removeEventListener(eventName, mockCallback);
+    document.body.removeChild(rootElement);
+  });
 });


### PR DESCRIPTION
This pull request addresses a bug in the `EventEmitter` class where custom events were incorrectly set to bubble by default. The fix ensures that event bubbling is now optional and defaults to `false` unless explicitly specified.

### Bug Fixes:
* **EventEmitter Class**:
  - Added a `bubbles` parameter to the `emit` method, defaulting to `false`, allowing developers to control whether the event should bubble up through the DOM.
  - Updated the `bubbles` property in the `CustomEvent` initialization to use the new `bubbles` parameter instead of always being `true`.

### Documentation:
* Added a changeset file to document the fix and its impact as a patch update for the `@ayu-sh-kr/dota-core` package.